### PR TITLE
Add vim ALE setup for config files

### DIFF
--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -249,6 +249,13 @@ a string that will be passed through to the Prettier command line tool:
 let g:ale_javascript_prettier_options = '--single-quote --trailing-comma es5'
 ```
 
+If you use Prettier config files, you must set
+`g:ale_javascript_prettier_use_local_config` to have ALE respect them:
+
+```vim
+let g:ale_javascript_prettier_use_local_config = 1
+```
+
 --------------------------------------------------------------------------------
 
 ### Running manually  


### PR DESCRIPTION
ALE does not enable config files by default in an effort to
avoid breaking installations using older versions of prettier:
https://github.com/w0rp/ale/issues/983